### PR TITLE
Optimal wavelength

### DIFF
--- a/dials_assign.py
+++ b/dials_assign.py
@@ -65,15 +65,15 @@ for i in trange(len(elist.imagesets())):
     # Optimize Miller indices
     la.assign()
     for j in range(macro_cycles):
+        la.reset_inliers()
         la.update_rotation()
         la.assign()
         la.reject_outliers()
+        la.update_rotation()
         la.assign()
-    la.reset_inliers()
-    la.assign()
 
-    # Recalculate s1 based on new wavelengths
-    s1 = la.s1 / la.wav[:,None]
+    # Update s1 based on new wavelengths
+    s1[la._inliers] = la.s1 / la.wav[:,None]
 
     # Reset crystal parameters based on new geometry
     cryst.set_U(la.R.flatten())

--- a/diffgeolib.py
+++ b/diffgeolib.py
@@ -370,7 +370,7 @@ class LaueAssigner():
         Hall = Hall[idx]
         qall = qall[idx]
 
-        wav_all  = -2.*(self.s0 * qall).sum(-1) / (qall*qall).sum(-1)
+        #wav_all  = -2.*(self.s0 * qall).sum(-1) / (qall*qall).sum(-1)
 
         dmat = rs.utils.angle_between(self.qobs[...,None,:], qall[None,...,:])
         cost = dmat
@@ -379,14 +379,15 @@ class LaueAssigner():
         _,idx = linear_sum_assignment(cost)
         H   = Hall[idx]
         qpred = qall[idx]
-        wav = wav_all[idx]
+        #wav = wav_all[idx]
         harmonics = harmonics[idx]
 
         # Set all attributes to match the current assignment
         self.set_H(H)
-        self.set_wav(wav)
+        #self.set_wav(wav)
         self.set_qpred(qpred)
         self.set_harmonics(harmonics)
+        self.set_wav(np.linalg.norm(self.qobs, axis=-1) / np.linalg.norm(self.qpred, axis=-1))
 
     def update_rotation(self):
         """ Update the rotation matrix (self.R) based on the inlying refls """

--- a/diffgeolib.py
+++ b/diffgeolib.py
@@ -370,7 +370,6 @@ class LaueAssigner():
         Hall = Hall[idx]
         qall = qall[idx]
 
-        #wav_all  = -2.*(self.s0 * qall).sum(-1) / (qall*qall).sum(-1)
 
         dmat = rs.utils.angle_between(self.qobs[...,None,:], qall[None,...,:])
         cost = dmat
@@ -379,15 +378,16 @@ class LaueAssigner():
         _,idx = linear_sum_assignment(cost)
         H   = Hall[idx]
         qpred = qall[idx]
-        #wav = wav_all[idx]
         harmonics = harmonics[idx]
 
         # Set all attributes to match the current assignment
         self.set_H(H)
-        #self.set_wav(wav)
         self.set_qpred(qpred)
         self.set_harmonics(harmonics)
-        self.set_wav(np.linalg.norm(self.qobs, axis=-1) / np.linalg.norm(self.qpred, axis=-1))
+
+        #wav_pred = -2.*(self.s0 * qpred).sum(-1) / (qpred*qpred).sum(-1)
+        wav_obs = np.linalg.norm(self.qobs, axis=-1) / np.linalg.norm(self.qpred, axis=-1)
+        self.set_wav(wav_obs)
 
     def update_rotation(self):
         """ Update the rotation matrix (self.R) based on the inlying refls """


### PR DESCRIPTION
This uses an analytical wavelength which is chosen to (approximately) minimize the difference between the observed and predicted scattering vectors. This is as opposed to the previous approach which assigned the wavelength appropriate for the centroid of the predicted scattering vector. 

This PR also changes the behavior during index assignment to exclude outliers from downstream processing. Previously we were not removing any outliers at this step and relying on DIALS outlier rejection at refinement time. 